### PR TITLE
fix typo in reinforce-zoo.cabal

### DIFF
--- a/reinforce-zoo/reinforce-zoo.cabal
+++ b/reinforce-zoo/reinforce-zoo.cabal
@@ -35,7 +35,7 @@ executable egreedy-bandits-example
 
 executable qtable-cartpole-example
   main-is: QTable.hs
-  hs-source-dirs: examples/frozenlake
+  hs-source-dirs: examples/cartpole
   default-language: Haskell2010
   ghc-options: -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
   build-depends:


### PR DESCRIPTION
`stack exec qtable-cartpole-example` runs frozenlake. This PR fixes that.